### PR TITLE
Validator updated to allow standard validation options

### DIFF
--- a/lib/validates_overlap/overlap_validator.rb
+++ b/lib/validates_overlap/overlap_validator.rb
@@ -9,7 +9,7 @@ class OverlapValidator < ActiveModel::EachValidator
   end
 
   def validate(record)
-    record.errors[attributes.first] << "is overlapped" if self.find_crossed(record)
+    record.errors[attributes.first] << (options[:message] || "is overlapped") if self.find_crossed(record)
   end
 
 


### PR DESCRIPTION
You can now validate models with the usual options:

``` ruby
validates :pickup_date, :dropoff_date, :overlap => { :message => "cannot overlap another booking"}
```
