### PR TITLE
Update overlap_validator.rb to allow to provide a custom validation message and title

### DIFF
--- a/lib/validates_overlap/overlap_validator.rb
+++ b/lib/validates_overlap/overlap_validator.rb
@@ -15,9 +15,9 @@ class OverlapValidator < ActiveModel::EachValidator
   def validate(record)
     if self.find_crossed(record)
       if record.respond_to? attributes.first
-        record.errors.add(attributes.first, :overlap)
+        record.errors.add(options[:message_title] || attributes.first, options[:message_content] || :overlap)
       else
-        record.errors.add(:base, :overlap)
+        record.errors.add(options[:message_title] || :base, options[:message_content] || :overlap
       end
     end
   end


### PR DESCRIPTION
## Update overlap_validator.rb to allow to provide a custom validation message and title

It is now possible to provide a custom validation message and a custom message title 

eg :  
validates :starts_at, :ends_at, :overlap => {message_content: "Two meetings cannot happen at the same time",message_title: "Start time and end time of the meeting"}
