### PR TITLE
Use Rails 4.2-compatible method for primary key

### DIFF
--- a/lib/validates_overlap/overlap_validator.rb
+++ b/lib/validates_overlap/overlap_validator.rb
@@ -87,7 +87,7 @@ class OverlapValidator < ActiveModel::EachValidator
   end
 
   def primary_key(record)
-    record.class.columns.find(&:primary).name
+    record.class.primary_key
   end
 
   # Generate sql condition for time range cross


### PR DESCRIPTION
While testing against the Rails 4.2 beta (beta4), specs were failing due to
the use of the `#primary` method against database columns to determine the
primary key. Calling `.primary_key` on the record's class successfully fetches
the primary key column name in Rails 3 and 4 in a way that is compatible with
Rails 4.2.
