### PR TITLE
If value of scope attribute is NULL, then use IS NULL to compare

### DIFF
--- a/lib/validates_overlap/overlap_validator.rb
+++ b/lib/validates_overlap/overlap_validator.rb
@@ -139,7 +139,13 @@ class OverlapValidator < ActiveModel::EachValidator
   # Add attribute and his value to sql condition
   def add_attribute(record, attr_name, value = nil)
     _value = resolve_scope_value(record, attr_name, value)
-    operator = _value.is_a?(Array) ? " IN (:%s)" : " = :%s"
+    operator = if _value.nil?
+      " IS NULL"
+    elsif _value.is_a?(Array)
+      " IN (:%s)"
+    else
+      " = :%s"
+    end
 
     self.sql_conditions += " AND #{attribute_to_sql(attr_name, record)} #{operator}" % value_attribute_name(attr_name)
     self.sql_values.merge!({:"#{value_attribute_name(attr_name)}" => _value})


### PR DESCRIPTION
In our application, we are using validates_overlap with a scope that points to a parent record's id. When creating a new record, if the parent record is not saved yet then the parent record's id will be NULL.

Unfortunately, the current code in add_attributes does: value = NULL, which will never evaluate to true. This PR changes add_attributes to do value IS NULL.