### PR TITLE
Change send to read_attribute

### DIFF
--- a/lib/validates_overlap/overlap_validator.rb
+++ b/lib/validates_overlap/overlap_validator.rb
@@ -165,7 +165,7 @@ class OverlapValidator < ActiveModel::EachValidator
     if value
       value.is_a?(Proc) ? value.call(record) : value
     else
-      record.send(:"#{attr_name}")
+      record.read_attribute(attr_name)
     end
   end
 


### PR DESCRIPTION
- in the case of enum attributes, the send returned the value from enum definition and not value stored in database