### PR TITLE
Avoid implicit `scoped_model.all` delegation in the validation

### DIFF
--- a/lib/validates_overlap/overlap_validator.rb
+++ b/lib/validates_overlap/overlap_validator.rb
@@ -40,7 +40,8 @@ class OverlapValidator < ActiveModel::EachValidator
   protected
 
   def initialize_query(record, options = {})
-    self.scoped_model = options[:scoped_model].present? ? options[:scoped_model].constantize : record.class
+    scoped_model = options[:scoped_model].present? ? options[:scoped_model].constantize : record.class
+    self.scoped_model = scoped_model.default_scoped
     generate_overlap_sql_values(record)
     generate_overlap_sql_conditions(record)
     add_attributes(record, options[:scope]) if options && options[:scope].present?


### PR DESCRIPTION
Validations are sometimes called in the deprecated leaking scoping https://github.com/rails/rails/pull/35280 (e.g. `find_or_create_by` etc).

To avoid that warning, we should not delegate to (implicit) `scoped_model.all`.

Fixes #51.