### PR TITLE
Refactor code to support mongoid database engines

### DIFF
--- a/lib/validates_overlap/adapters/active_record_adapter.rb
+++ b/lib/validates_overlap/adapters/active_record_adapter.rb
@@ -1,0 +1,159 @@
+module ValidatesOverlap
+  class ActiveRecordAdapter < DatabaseAdapter
+    # Initialize the query for the given record and options
+    def initialize_query(record, options = {})
+      scoped_model = options[:scoped_model].present? ? options[:scoped_model].constantize : record.class
+      @scoped_model = scoped_model.default_scoped
+      generate_overlap_sql_values(record)
+      generate_overlap_sql_conditions(record)
+      add_attributes(record, options[:scope]) if options && options[:scope].present?
+      add_query_options(options[:query_options]) if options && options[:query_options].present?
+    end
+
+    # Check if there exists at least one record in the database that overlaps with the current record
+    def overlapped_exists?
+      @scoped_model.exists?([@sql_conditions, @sql_values])
+    end
+
+    # Get the overlapped records from the database
+    def get_overlapped
+      @scoped_model.where([@sql_conditions, @sql_values])
+    end
+
+    # Prepare attribute names to use in SQL conditions
+    def attributes_to_sql(record)
+      record.attributes.map { |attr| attribute_to_sql(attr, record) }
+    end
+
+    # Prepare attribute name to use in SQL conditions created in the form 'table_name.attribute_name'
+    def attribute_to_sql(attr, record)
+      if attr.to_s.include?('.')
+        attr
+      else
+        "#{record_table_name(record)}.#{attr}"
+      end
+    end
+
+    # Generate SQL condition for time range overlap
+    def generate_overlap_sql_conditions(record)
+      starts_at_attr, ends_at_attr = attributes_to_sql(record)
+      main_condition = condition_string(starts_at_attr, ends_at_attr)
+      primary_key_name = primary_key(record)
+      key = primary_key_value(primary_key_name, record)
+      if record.new_record?
+        @sql_conditions = main_condition
+      else
+        @sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key(record)} !="
+        @sql_conditions += key.is_a?(String) ? "'#{key}'" : key.to_s
+      end
+    end
+
+    # Return hash of values for overlap SQL condition
+    def generate_overlap_sql_values(record)
+      starts_at_value, ends_at_value = resolve_values_from_attributes(record)
+      starts_at_value += options.fetch(:start_shift) { 0 } if starts_at_value && options
+      ends_at_value += options.fetch(:end_shift) { 0 } if ends_at_value && options
+      @sql_values = { starts_at_value: starts_at_value || BEGIN_OF_UNIX_TIME, ends_at_value: ends_at_value || END_OF_UNIX_TIME }
+    end
+
+    private
+
+    def resolve_values_from_attributes(record)
+      record.attributes.map do |attr|
+        if attr.to_s.include?('.')
+          get_assoc_value(record, attr)
+        else
+          record.send(attr.to_sym)
+        end
+      end
+    end
+
+    def get_assoc_value(record, attr)
+      assoc, attr_name = attr.to_s.split('.')
+      assoc_name = assoc.singularize.to_sym
+      assoc_obj = record.send(assoc_name) if record.respond_to?(assoc_name)
+      (assoc_obj || record).send(attr_name.to_sym)
+    end
+
+    def record_table_name(record)
+      record.class.table_name
+    end
+
+    def primary_key(record)
+      record.class.primary_key
+    end
+
+    def primary_key_value(primary_key_name, record)
+      record.send(primary_key_name)
+    end
+
+    def condition_string(starts_at_attr, ends_at_attr)
+      except_option = Array(options[:exclude_edges]).map(&:to_s)
+      starts_at_sign = except_option.include?(starts_at_attr.to_s.split('.').last) ? '<' : '<='
+      ends_at_sign = except_option.include?(ends_at_attr.to_s.split('.').last) ? '>' : '>='
+      query = []
+      query << "(#{ends_at_attr} IS NULL OR #{ends_at_attr} #{ends_at_sign} :starts_at_value)"
+      query << "(#{starts_at_attr} IS NULL OR #{starts_at_attr} #{starts_at_sign} :ends_at_value)"
+      query.join(' AND ')
+    end
+
+    def add_attributes(record, attrs)
+      if attrs.is_a?(Array)
+        attrs.each { |attr| add_attribute(record, attr) }
+      elsif attrs.is_a?(Hash)
+        attrs.each do |attr_name, value|
+          add_attribute(record, attr_name, value)
+        end
+      else
+        add_attribute(record, attrs)
+      end
+    end
+
+    def add_attribute(record, attr_name, value = nil)
+      _value = resolve_attribute_value(record, attr_name, value)
+      operator = if _value.nil?
+                   ' IS NULL'
+                 elsif _value.is_a?(Array)
+                   ' IN (:%s)'
+                 else
+                   ' = :%s'
+      end
+
+      @sql_conditions += " AND #{attribute_to_sql(attr_name, record)} #{operator}" % value_attribute_name(attr_name)
+      @sql_values.merge!(:"#{value_attribute_name(attr_name)}" => _value)
+    end
+
+    def value_attribute_name(attr_name)
+      name = attr_name.to_s.include?('.') ? attr_name.to_s.gsub('.', '_') : attr_name.to_s
+      name + '_value'
+    end
+
+    def resolve_attribute_value(record, attr_name, value = nil)
+      if value
+        value.is_a?(Proc) ? value.call(record) : value
+      else
+        value = record.read_attribute(attr_name)
+
+        if is_enum_attribute?(record, attr_name)
+          value = record.class.defined_enums[attr_name][value]
+        end
+
+        value
+      end
+    end
+
+    def is_enum_attribute?(record, attr_name)
+      implement_enum? && record.class.defined_enums[attr_name.to_s].present?
+    end
+
+    def implement_enum?
+      (ActiveRecord::VERSION::MAJOR >= 5) || (ActiveRecord::VERSION::MAJOR > 4 && ActiveRecord::VERSION::MINOR > 1)
+    end
+
+    def add_query_options(methods)
+      methods.each do |method_name, params|
+        @scoped_model = @scoped_model.send(method_name.to_sym, *params)
+      end
+    end
+  end
+end

--- a/lib/validates_overlap/adapters/mongoid_adapter.rb
+++ b/lib/validates_overlap/adapters/mongoid_adapter.rb
@@ -1,0 +1,141 @@
+module ValidatesOverlap
+  class MongoidAdapter < DatabaseAdapter
+    # Initialize the query for the given record and options
+    def initialize_query(record, options = {})
+      scoped_model = options[:scoped_model].present? ? options[:scoped_model].constantize : record.class
+      @scoped_model = scoped_model.all
+      generate_overlap_conditions(record)
+      add_attributes(record, options[:scope]) if options && options[:scope].present?
+      add_query_options(options[:query_options]) if options && options[:query_options].present?
+    end
+
+    # Check if there exists at least one record in the database that overlaps with the current record
+    def overlapped_exists?
+      @scoped_model.where(@conditions).exists?
+    end
+
+    # Get the overlapped records from the database
+    def get_overlapped
+      @scoped_model.where(@conditions)
+    end
+
+    # Prepare attribute names to use in Mongoid conditions
+    def attributes_to_mongoid(record)
+      record.attributes.map { |attr| attribute_to_mongoid(attr, record) }
+    end
+
+    # Prepare attribute name to use in Mongoid conditions created in the form 'attribute_name'
+    def attribute_to_mongoid(attr, record)
+      attr.to_s.include?('.') ? attr : attr.to_s
+    end
+
+    # Generate Mongoid condition for time range overlap
+    def generate_overlap_conditions(record)
+      starts_at_attr, ends_at_attr = attributes_to_mongoid(record)
+      main_condition = condition_string(starts_at_attr, ends_at_attr)
+      primary_key_name = primary_key(record)
+      key = primary_key_value(primary_key_name, record)
+      if record.new_record?
+        @conditions = main_condition
+      else
+        @conditions = main_condition.merge({ primary_key_name => { '$ne' => key } })
+      end
+    end
+
+    # Return hash of values for overlap Mongoid condition
+    def generate_overlap_sql_values(record)
+      starts_at_value, ends_at_value = resolve_values_from_attributes(record)
+      starts_at_value += options.fetch(:start_shift) { 0 } if starts_at_value && options
+      ends_at_value += options.fetch(:end_shift) { 0 } if ends_at_value && options
+      @sql_values = { starts_at_value: starts_at_value || BEGIN_OF_UNIX_TIME, ends_at_value: ends_at_value || END_OF_UNIX_TIME }
+    end
+
+    private
+
+    def resolve_values_from_attributes(record)
+      record.attributes.map do |attr|
+        if attr.to_s.include?('.')
+          get_assoc_value(record, attr)
+        else
+          record.send(attr.to_sym)
+        end
+      end
+    end
+
+    def get_assoc_value(record, attr)
+      assoc, attr_name = attr.to_s.split('.')
+      assoc_name = assoc.singularize.to_sym
+      assoc_obj = record.send(assoc_name) if record.respond_to?(assoc_name)
+      (assoc_obj || record).send(attr_name.to_sym)
+    end
+
+    def primary_key(record)
+      record.class.primary_key
+    end
+
+    def primary_key_value(primary_key_name, record)
+      record.send(primary_key_name)
+    end
+
+    def condition_string(starts_at_attr, ends_at_attr)
+      except_option = Array(options[:exclude_edges]).map(&:to_s)
+      starts_at_sign = except_option.include?(starts_at_attr.to_s.split('.').last) ? '$lt' : '$lte'
+      ends_at_sign = except_option.include?(ends_at_attr.to_s.split('.').last) ? '$gt' : '$gte'
+      {
+        '$or' => [
+          { ends_at_attr => { '$eq' => nil, ends_at_sign => :starts_at_value } },
+          { starts_at_attr => { '$eq' => nil, starts_at_sign => :ends_at_value } }
+        ]
+      }
+    end
+
+    def add_attributes(record, attrs)
+      if attrs.is_a?(Array)
+        attrs.each { |attr| add_attribute(record, attr) }
+      elsif attrs.is_a?(Hash)
+        attrs.each do |attr_name, value|
+          add_attribute(record, attr_name, value)
+        end
+      else
+        add_attribute(record, attrs)
+      end
+    end
+
+    def add_attribute(record, attr_name, value = nil)
+      _value = resolve_attribute_value(record, attr_name, value)
+      operator = if _value.nil?
+                   { '$eq' => nil }
+                 elsif _value.is_a?(Array)
+                   { '$in' => _value }
+                 else
+                   { '$eq' => _value }
+      end
+
+      @conditions[attr_name] = operator
+    end
+
+    def resolve_attribute_value(record, attr_name, value = nil)
+      if value
+        value.is_a?(Proc) ? value.call(record) : value
+      else
+        value = record.read_attribute(attr_name)
+
+        if is_enum_attribute?(record, attr_name)
+          value = record.class.defined_enums[attr_name][value]
+        end
+
+        value
+      end
+    end
+
+    def is_enum_attribute?(record, attr_name)
+      record.class.defined_enums[attr_name.to_s].present?
+    end
+
+    def add_query_options(methods)
+      methods.each do |method_name, params|
+        @scoped_model = @scoped_model.send(method_name.to_sym, *params)
+      end
+    end
+  end
+end

--- a/lib/validates_overlap/database_adapter.rb
+++ b/lib/validates_overlap/database_adapter.rb
@@ -1,0 +1,38 @@
+module ValidatesOverlap
+  class DatabaseAdapter
+    # Initialize the query for the given record and options
+    def initialize_query(record, options = {})
+      raise NotImplementedError, 'Subclasses must implement the initialize_query method'
+    end
+
+    # Check if there exists at least one record in the database that overlaps with the current record
+    def overlapped_exists?
+      raise NotImplementedError, 'Subclasses must implement the overlapped_exists? method'
+    end
+
+    # Get the overlapped records from the database
+    def get_overlapped
+      raise NotImplementedError, 'Subclasses must implement the get_overlapped method'
+    end
+
+    # Prepare attribute names to use in SQL conditions
+    def attributes_to_sql(record)
+      raise NotImplementedError, 'Subclasses must implement the attributes_to_sql method'
+    end
+
+    # Prepare attribute name to use in SQL conditions created in the form 'table_name.attribute_name'
+    def attribute_to_sql(attr, record)
+      raise NotImplementedError, 'Subclasses must implement the attribute_to_sql method'
+    end
+
+    # Generate SQL condition for time range overlap
+    def generate_overlap_sql_conditions(record)
+      raise NotImplementedError, 'Subclasses must implement the generate_overlap_sql_conditions method'
+    end
+
+    # Return hash of values for overlap SQL condition
+    def generate_overlap_sql_values(record)
+      raise NotImplementedError, 'Subclasses must implement the generate_overlap_sql_values method'
+    end
+  end
+end

--- a/lib/validates_overlap/overlap_validator.rb
+++ b/lib/validates_overlap/overlap_validator.rb
@@ -1,4 +1,7 @@
 require 'active_support/i18n'
+require 'validates_overlap/database_adapter'
+require 'validates_overlap/adapters/active_record_adapter'
+require 'validates_overlap/adapters/mongoid_adapter'
 
 I18n.load_path << File.dirname(__FILE__) + '/locale/en.yml'
 
@@ -6,21 +9,19 @@ class OverlapValidator < ActiveModel::EachValidator
   BEGIN_OF_UNIX_TIME = Time.at(-2_147_483_648).to_datetime
   END_OF_UNIX_TIME = Time.at(2_147_483_648).to_datetime
 
-  attr_accessor :sql_conditions
-  attr_accessor :sql_values
-  attr_accessor :scoped_model
+  attr_accessor :database_adapter
 
   def initialize(args)
     attributes_are_range(args[:attributes])
-
     super
+    @database_adapter = determine_database_adapter(args[:attributes].first)
   end
 
   def validate(record)
-    initialize_query(record, options)
-    if overlapped_exists?
+    database_adapter.initialize_query(record, options)
+    if database_adapter.overlapped_exists?
       if options[:load_overlapped]
-        record.instance_variable_set(:@overlapped_records, get_overlapped)
+        record.instance_variable_set(:@overlapped_records, database_adapter.get_overlapped)
       end
 
       if record.respond_to? attributes.first
@@ -39,170 +40,15 @@ class OverlapValidator < ActiveModel::EachValidator
 
   protected
 
-  def initialize_query(record, options = {})
-    scoped_model = options[:scoped_model].present? ? options[:scoped_model].constantize : record.class
-    self.scoped_model = scoped_model.default_scoped
-    generate_overlap_sql_values(record)
-    generate_overlap_sql_conditions(record)
-    add_attributes(record, options[:scope]) if options && options[:scope].present?
-    add_query_options(options[:query_options]) if options && options[:query_options].present?
-  end
-
-  # Check if exists at least one record in DB which is overlapped with current record
-  def overlapped_exists?
-    scoped_model.exists?([sql_conditions, sql_values])
-  end
-
-  def get_overlapped
-    scoped_model.where([sql_conditions, sql_values])
-  end
-
-  # Resolve attributes values from record to use in sql conditions
-  # return array in form ['2011-01-10', '2011-02-20']
-  def resolve_values_from_attributes(record)
-    attributes.map do |attr|
-      if attr.to_s.include?('.')
-        get_assoc_value(record, attr)
-      else
-        record.send(attr.to_sym)
-      end
-    end
-  end
-
-  def get_assoc_value(record, attr)
-    assoc, attr_name = attr.to_s.split('.')
-    assoc_name = assoc.singularize.to_sym
-    assoc_obj = record.send(assoc_name) if record.respond_to?(assoc_name)
-    (assoc_obj || record).send(attr_name.to_sym)
-  end
-  # Prepare attribute names to use in sql conditions
-  # return array in form ['meetings.starts_at', 'meetings.ends_at']
-  def attributes_to_sql(record)
-    attributes.map { |attr| attribute_to_sql(attr, record) }
-  end
-
-  # Prepare attribute name to use in sql conditions created in form 'table_name.attribute_name'
-  def attribute_to_sql(attr, record)
-    if attr.to_s.include?('.')
-      attr
+  def determine_database_adapter(attribute)
+    if attribute.to_s.include?('.')
+      ValidatesOverlap::MongoidAdapter.new
     else
-      "#{record_table_name(record)}.#{attr}"
+      ValidatesOverlap::ActiveRecordAdapter.new
     end
   end
 
-  # Get the table name for the record
-  def record_table_name(record)
-    record.class.table_name
-  end
-
-  # Check if the validation of time range is defined by 2 attributes
   def attributes_are_range(attributes)
     fail 'Validation of time range must be defined by 2 attributes' unless attributes.size == 2
-  end
-
-  def primary_key(record)
-    record.class.primary_key
-  end
-
-  def primary_key_value(primary_key_name, record)
-    record.send(primary_key_name)
-  end
-
-  # Generate sql condition for time range cross
-  def generate_overlap_sql_conditions(record)
-    starts_at_attr, ends_at_attr = attributes_to_sql(record)
-    main_condition = condition_string(starts_at_attr, ends_at_attr)
-    primary_key_name = primary_key(record)
-    key = primary_key_value(primary_key_name, record)
-    if record.new_record?
-      self.sql_conditions = main_condition
-    else
-      self.sql_conditions = "#{main_condition} AND #{record_table_name(record)}.#{primary_key(record)} !="
-      self.sql_conditions +=   key.is_a?(String) ? "'#{key}'" : key.to_s
-    end
-  end
-
-  # Return hash of values for overlap sql condition
-  def generate_overlap_sql_values(record)
-    starts_at_value, ends_at_value = resolve_values_from_attributes(record)
-    starts_at_value += options.fetch(:start_shift) { 0 } if starts_at_value && options
-    ends_at_value += options.fetch(:end_shift) { 0 } if ends_at_value && options
-    self.sql_values = { starts_at_value: starts_at_value || BEGIN_OF_UNIX_TIME, ends_at_value: ends_at_value || END_OF_UNIX_TIME }
-  end
-
-  # Return the condition string depend on exclude_edges option.
-  def condition_string(starts_at_attr, ends_at_attr)
-    except_option = Array(options[:exclude_edges]).map(&:to_s)
-    starts_at_sign = except_option.include?(starts_at_attr.to_s.split('.').last) ? '<' : '<='
-    ends_at_sign = except_option.include?(ends_at_attr.to_s.split('.').last) ? '>' : '>='
-    query = []
-    query << "(#{ends_at_attr} IS NULL OR #{ends_at_attr} #{ends_at_sign} :starts_at_value)"
-    query << "(#{starts_at_attr} IS NULL OR #{starts_at_attr} #{starts_at_sign} :ends_at_value)"
-    query.join(' AND ')
-  end
-
-  # Add attributes and values to sql conditions.
-  # helps to use with scope options, so scope can be added as this forms :scope => "user_id" or :scope => ["user_id", "place_id"]
-  def add_attributes(record, attrs)
-    if attrs.is_a?(Array)
-      attrs.each { |attr| add_attribute(record, attr) }
-    elsif attrs.is_a?(Hash)
-      attrs.each do |attr_name, value|
-        add_attribute(record, attr_name, value)
-      end
-    else
-      add_attribute(record, attrs)
-    end
-  end
-
-  # Add attribute and his value to sql condition
-  def add_attribute(record, attr_name, value = nil)
-    _value = resolve_attribute_value(record, attr_name, value)
-    operator = if _value.nil?
-                 ' IS NULL'
-               elsif _value.is_a?(Array)
-                 ' IN (:%s)'
-               else
-                 ' = :%s'
-    end
-
-    self.sql_conditions += " AND #{attribute_to_sql(attr_name, record)} #{operator}" % value_attribute_name(attr_name)
-    sql_values.merge!(:"#{value_attribute_name(attr_name)}" => _value)
-  end
-
-  def value_attribute_name(attr_name)
-    name = attr_name.to_s.include?('.') ? attr_name.to_s.gsub('.', '_') : attr_name.to_s
-    name + '_value'
-  end
-
-  def resolve_attribute_value(record, attr_name, value = nil)
-    if value
-      value.is_a?(Proc) ? value.call(record) : value
-    else
-      value = record.read_attribute(attr_name)
-
-      if is_enum_attribute?(record, attr_name)
-        value = record.class.defined_enums[attr_name][value]
-      end
-
-      value
-    end
-  end
-
-  def is_enum_attribute?(record, attr_name)
-    implement_enum? && record.class.defined_enums[attr_name.to_s].present?
-  end
-
-  def implement_enum?
-    (ActiveRecord::VERSION::MAJOR >= 5) || (ActiveRecord::VERSION::MAJOR > 4 && ActiveRecord::VERSION::MINOR > 1)
-  end
-
-  # Allow to use scope, joins, includes methods before querying
-  # == Example:
-  # validates_overlap :date_from, :date_to, :query_options => {:includes => "visits"}
-  def add_query_options(methods)
-    methods.each do |method_name, params|
-      self.scoped_model = scoped_model.send(method_name.to_sym, *params)
-    end
   end
 end

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -20,3 +20,12 @@ production:
   database: db/production.sqlite3
   pool: 5
   timeout: 5000
+
+mongoid:
+  clients:
+    default:
+      database: mongoid_test
+      hosts:
+        - localhost:27017
+      options:
+        server_selection_timeout: 5

--- a/spec/mongoid/meeting_spec.rb
+++ b/spec/mongoid/meeting_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'mongoid'
+
+Mongoid.load!(File.expand_path('../../dummy/config/database.yml', __FILE__), :mongoid)
+
+class MongoidMeeting
+  include Mongoid::Document
+  field :starts_at, type: Date
+  field :ends_at, type: Date
+
+  validates :starts_at, :ends_at, overlap: { load_overlapped: true }
+end
+
+describe MongoidMeeting do
+  context 'Validation' do
+    it 'create meeting' do
+      expect do
+        MongoidMeeting.create(starts_at: '2022-01-01'.to_date, ends_at: '2022-01-02'.to_date)
+      end.to change(MongoidMeeting, :count).by(1)
+    end
+
+    context 'simple validation' do
+      let!(:existing_meeting) { MongoidMeeting.create(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date) }
+
+      OVERLAP_TIME_RANGES.each do |description, time_range|
+        it "is not valid if exists meeting which #{description}" do
+          meeting = MongoidMeeting.new(starts_at: time_range.first, ends_at: time_range.last)
+          expect(meeting).not_to be_valid
+          expect(meeting.errors[:starts_at]).not_to be_empty
+          expect(meeting.errors[:ends_at]).to be_empty
+        end
+      end
+
+      it 'validate object which has not got overlap' do
+        meeting = MongoidMeeting.new(starts_at: '2022-01-09'.to_date, ends_at: '2022-01-11'.to_date)
+        expect(meeting).to be_valid
+        expect(meeting.errors[:starts_at]).to be_empty
+        expect(meeting.errors[:ends_at]).to be_empty
+
+        meeting = MongoidMeeting.new(starts_at: '2022-01-01'.to_date, ends_at: '2022-01-02'.to_date)
+        expect(meeting).to be_valid
+        expect(meeting.errors[:starts_at]).to be_empty
+        expect(meeting.errors[:ends_at]).to be_empty
+      end
+
+      describe '@overlapped_records' do
+        it 'store the overlapped records' do
+          meeting = MongoidMeeting.new(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+          expect(meeting).not_to be_valid
+          expect(meeting.instance_variable_get(:@overlapped_records)).to eq [existing_meeting]
+        end
+      end
+    end
+
+    context 'Validation of endless objects' do
+      it 'with overlap object' do
+        MongoidMeeting.create(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+        meeting = MongoidMeeting.new(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+        expect(meeting).not_to be_valid
+        meeting = MongoidMeeting.new(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+        expect(meeting).not_to be_valid
+        meeting = MongoidMeeting.new(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+        expect(meeting).to be_valid
+      end
+
+      it 'with another endless object' do
+        MongoidMeeting.create(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+
+        meeting = MongoidMeeting.new(starts_at: '2022-01-05'.to_date, ends_at: nil)
+        expect(meeting).not_to be_valid
+        meeting = MongoidMeeting.new(starts_at: nil, ends_at: '2022-01-05'.to_date)
+        expect(meeting).to be_valid
+        meeting = MongoidMeeting.new(starts_at: nil, ends_at: nil)
+        expect(meeting).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/mongoid/shift_spec.rb
+++ b/spec/mongoid/shift_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'mongoid'
+
+Mongoid.load!(File.expand_path('../../dummy/config/database.yml', __FILE__), :mongoid)
+
+class MongoidShift
+  include Mongoid::Document
+  field :starts_at, type: Date
+  field :ends_at, type: Date
+
+  validates :starts_at, :ends_at, overlap: { load_overlapped: true }
+end
+
+describe MongoidShift do
+  context 'Validation' do
+    it 'create shift' do
+      expect do
+        MongoidShift.create(starts_at: '2022-01-01'.to_date, ends_at: '2022-01-02'.to_date)
+      end.to change(MongoidShift, :count).by(1)
+    end
+
+    context 'simple validation' do
+      let!(:existing_shift) { MongoidShift.create(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date) }
+
+      OVERLAP_TIME_RANGES.each do |description, time_range|
+        it "is not valid if exists shift which #{description}" do
+          shift = MongoidShift.new(starts_at: time_range.first, ends_at: time_range.last)
+          expect(shift).not_to be_valid
+          expect(shift.errors[:starts_at]).not_to be_empty
+          expect(shift.errors[:ends_at]).to be_empty
+        end
+      end
+
+      it 'validate object which has not got overlap' do
+        shift = MongoidShift.new(starts_at: '2022-01-09'.to_date, ends_at: '2022-01-11'.to_date)
+        expect(shift).to be_valid
+        expect(shift.errors[:starts_at]).to be_empty
+        expect(shift.errors[:ends_at]).to be_empty
+
+        shift = MongoidShift.new(starts_at: '2022-01-01'.to_date, ends_at: '2022-01-02'.to_date)
+        expect(shift).to be_valid
+        expect(shift.errors[:starts_at]).to be_empty
+        expect(shift.errors[:ends_at]).to be_empty
+      end
+
+      describe '@overlapped_records' do
+        it 'store the overlapped records' do
+          shift = MongoidShift.new(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+          expect(shift).not_to be_valid
+          expect(shift.instance_variable_get(:@overlapped_records)).to eq [existing_shift]
+        end
+      end
+    end
+
+    context 'Validation of endless objects' do
+      it 'with overlap object' do
+        MongoidShift.create(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+        shift = MongoidShift.new(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+        expect(shift).not_to be_valid
+        shift = MongoidShift.new(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+        expect(shift).not_to be_valid
+        shift = MongoidShift.new(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+        expect(shift).to be_valid
+      end
+
+      it 'with another endless object' do
+        MongoidShift.create(starts_at: '2022-01-05'.to_date, ends_at: '2022-01-08'.to_date)
+
+        shift = MongoidShift.new(starts_at: '2022-01-05'.to_date, ends_at: nil)
+        expect(shift).not_to be_valid
+        shift = MongoidShift.new(starts_at: nil, ends_at: '2022-01-05'.to_date)
+        expect(shift).to be_valid
+        shift = MongoidShift.new(starts_at: nil, ends_at: nil)
+        expect(shift).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refactor the code to support multiple database engines, including Mongoid.

* Add `lib/validates_overlap/database_adapter.rb` to define the abstract database adapter interface.
* Add `lib/validates_overlap/adapters/active_record_adapter.rb` to implement the database adapter for ActiveRecord.
* Add `lib/validates_overlap/adapters/mongoid_adapter.rb` to implement the database adapter for Mongoid.
* Modify `lib/validates_overlap/overlap_validator.rb` to use the abstract database adapter interface and remove ActiveRecord-specific methods and assumptions.
* Update `spec/dummy/config/database.yml` to include Mongoid configuration for testing.
* Add `spec/mongoid/meeting_spec.rb` to write tests for Mongoid database, including tests for creating a meeting, validating overlapping meetings, and validating non-overlapping meetings.
* Add `spec/mongoid/shift_spec.rb` to write tests for Mongoid database, including tests for creating a shift, validating overlapping shifts, and validating non-overlapping shifts.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/robinbortlik/validates_overlap/pull/56?shareId=448f99d6-4c4b-45d3-81ee-5cb889b4c3bd).